### PR TITLE
Improved runtime of has_bad_word

### DIFF
--- a/profanityfilter/profanityfilter.py
+++ b/profanityfilter/profanityfilter.py
@@ -1,6 +1,6 @@
 import os
 import re
-
+import string
 import inflection
 
 
@@ -70,7 +70,9 @@ class ProfanityFilter:
         for word in self.get_profane_words():
             prof[word.lower()] = True
         for word in text.split():
-            if prof.get(word.lower(), False):
+            lower = word.lower()
+            without_punc = ''.join(ch for ch in lower if ch not in set(string.punctuation))
+            if prof.get(lower, False) or prof.get(without_punc, False):
                 return True
         return False
 

--- a/profanityfilter/profanityfilter.py
+++ b/profanityfilter/profanityfilter.py
@@ -69,7 +69,7 @@ class ProfanityFilter:
         prof = {}
         for word in self.get_profane_words():
             prof[word] = True
-        for word in input_text.split():
+        for word in text.split():
             if prof.get(word, False):
                 return True
         return False
@@ -131,4 +131,3 @@ class ProfanityFilter:
     def is_profane(self, input_text):
         """Returns True if input_text contains any profane words, False otherwise."""
         return self.has_bad_word(input_text)
-        

--- a/profanityfilter/profanityfilter.py
+++ b/profanityfilter/profanityfilter.py
@@ -68,9 +68,9 @@ class ProfanityFilter:
         """Returns True if text contains profanity, False otherwise."""
         prof = {}
         for word in self.get_profane_words():
-            prof[word] = True
+            prof[word.lower()] = True
         for word in text.split():
-            if prof.get(word, False):
+            if prof.get(word.lower(), False):
                 return True
         return False
 

--- a/profanityfilter/profanityfilter.py
+++ b/profanityfilter/profanityfilter.py
@@ -66,7 +66,13 @@ class ProfanityFilter:
 
     def has_bad_word(self, text):
         """Returns True if text contains profanity, False otherwise."""
-        return self.censor(text) != text
+        prof = {}
+        for word in self.get_profane_words():
+            prof[word] = True
+        for word in input_text.split():
+            if prof.get(word, False):
+                return True
+        return False
 
     def get_custom_censor_list(self):
         """Returns the list of custom profane words."""
@@ -125,3 +131,4 @@ class ProfanityFilter:
     def is_profane(self, input_text):
         """Returns True if input_text contains any profane words, False otherwise."""
         return self.has_bad_word(input_text)
+        


### PR DESCRIPTION
These methods used to have quadratic runtime of O(|Profane Words| * |input_text|) (possible even slower if you consider the runtime of the regex operations within the censor method). Using censor to implement has_bad_word is fundamentally inefficient. I wanted to use ProfanityFilter on my large dataset (millions of YouTube comments) and it was prohibitively slow. My new implementation leverages a dictionary to run in linear time and quits early if it finds a profane word, rather than doing tons of unnecessary computations. The old implementation made little progress in an hour on my dataset, whereas my implementation did the whole dataset in under 2 minutes. 